### PR TITLE
chore(readme): Move firebase install to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 - Jest
 - React Testing Library
 
+## Prerequisites
+
+- Install firebase tools: `npm install -g firebase-tools`
+
 ## Getting Started
 
 - Run `npm install`
@@ -25,5 +29,4 @@
 
 ### Deploy
 
-- Install firebase tools: `npm install -g firebase-tools`
 - Run `firebase deploy`


### PR DESCRIPTION
Moving the firebase tools install portion of the readme to prerequisites as it's required to run npm start.